### PR TITLE
v1.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 1.0.7
+
+- `AsyncField`:
+  - Added `isFetching`.
+  - `get`: now respect the current fetching `Future`.
+- lints: ^2.0.1
+- test: ^1.22.2
+- coverage: ^1.6.2
+
 ## 1.0.6
 
 - `AsyncStorage`:

--- a/lib/src/async_field_base.dart
+++ b/lib/src/async_field_base.dart
@@ -222,6 +222,9 @@ class AsyncField<T> {
   ///
   /// A slate value is when the current value exists but is expired. Can
   /// be used before a fetch is performed.
+  ///
+  /// If [isFetching] is `true` it will return the current fetching [Future].
+  /// See [refresh].
   FutureOr<T> get({void Function(T slate)? onSlateValue}) {
     var slate = checkValueTimeout();
 
@@ -237,6 +240,16 @@ class AsyncField<T> {
       var value = refresh();
       return value;
     } else {
+      var fetching = _fetching;
+
+      if (fetching != null) {
+        if (onSlateValue != null && slate != null) {
+          onSlateValue(slate);
+        }
+
+        return fetching;
+      }
+
       return _value as T;
     }
   }
@@ -323,6 +336,8 @@ class AsyncField<T> {
   bool get canRefresh => (fetcher != null || storage.canFetch) && !isClosed;
 
   Future<T>? _fetching;
+
+  bool get isFetching => _fetching != null;
 
   /// Refreshes this field and returns the fresh value.
   FutureOr<T> refresh() {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: async_field
 description: Async fields that can be stored or fetched from any source (databases, web services, local storage or other thread/isolate), with observable values, caches and stale versions.
-version: 1.0.6
+version: 1.0.7
 homepage: https://github.com/eneural-net/async_field
 
 environment:
@@ -11,7 +11,7 @@ dependencies:
   async_extension: ^1.0.12
 
 dev_dependencies:
-  lints: ^2.0.0
-  test: ^1.21.4
+  lints: ^2.0.1
+  test: ^1.22.2
   dependency_validator: ^3.2.2
-  coverage: ^1.3.2
+  coverage: ^1.6.2


### PR DESCRIPTION
- `AsyncField`:
  - Added `isFetching`.
  - `get`: now respect the current fetching `Future`.
- lints: ^2.0.1
- test: ^1.22.2
- coverage: ^1.6.2