### PR TITLE
v1.1.0

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -37,7 +37,9 @@ jobs:
           dart run test --coverage=./coverage
           dart pub global run coverage:format_coverage --packages=.dart_tool/package_config.json --report-on=lib --lcov -o ./coverage/lcov.info -i ./coverage
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           directory: ./coverage/
           flags: unittests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - `AsyncField`:
   - `refresh`: ensure that `_fetching` is removed on error.
 
+- sdk: '>=3.0.0 <4.0.0'
+
 - collection: ^1.18.0
 - async_extension: ^1.2.12
 - lints: ^3.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 1.1.0
+
+- `AsyncField`:
+  - `refresh`: ensure that `_fetching` is removed on error.
+
+- collection: ^1.18.0
+- async_extension: ^1.2.12
+- lints: ^3.0.0
+- test: ^1.25.5
+- dependency_validator: ^3.2.3
+- coverage: ^1.8.0
+
 ## 1.0.8
 
 - `AsyncStorage`:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,17 +1,17 @@
 name: async_field
 description: Async fields that can be stored or fetched from any source (databases, web services, local storage or other thread/isolate), with observable values, caches and stale versions.
-version: 1.0.8
+version: 1.1.0
 homepage: https://github.com/eneural-net/async_field
 
 environment:
-  sdk: '>=2.18.0 <3.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dependencies:
-  collection: ^1.16.0
-  async_extension: ^1.1.0
+  collection: ^1.18.0
+  async_extension: ^1.2.12
 
 dev_dependencies:
-  lints: ^2.0.1
-  test: ^1.23.1
-  dependency_validator: ^3.2.2
-  coverage: ^1.6.3
+  lints: ^3.0.0
+  test: ^1.25.5
+  dependency_validator: ^3.2.3
+  coverage: ^1.8.0

--- a/test/async_field_test.dart
+++ b/test/async_field_test.dart
@@ -444,6 +444,102 @@ void main() {
       expect(field.value, isNull);
     });
 
+    test('AsyncStorage (fetch error)', () async {
+      var storage = AsyncStorage();
+
+      expect(storage.canFetch, isFalse);
+
+      var fetchCount = 0;
+
+      var field = storage.getField<String>('a').withFetcher((f) {
+        var c = ++fetchCount;
+        if (c == 1) {
+          throw StateError("Fetch Error");
+        }
+        return 'v:$c';
+      });
+
+      expect(field.canRefresh, isTrue);
+
+      expect(field.isSet, isFalse);
+      expect(field.value, isNull);
+
+      expect(
+          () async => field.get(),
+          throwsA(isA<StateError>()
+              .having((e) => e.message, 'message', equals('Fetch Error'))));
+
+      expect(field.isSet, isFalse);
+      expect(field.value, isNull);
+
+      expect(await field.get(), equals('v:2'));
+
+      expect(field.isSet, isTrue);
+      expect(field.value, isNotNull);
+      expect(field.value, equals('v:2'));
+
+      expect(await field.get(), equals('v:2'));
+
+      expect(field.isSet, isTrue);
+      expect(field.value, isNotNull);
+      expect(field.value, equals('v:2'));
+
+      expect(await field.refresh(), equals('v:3'));
+
+      expect(field.isSet, isTrue);
+      expect(field.value, isNotNull);
+      expect(field.value, equals('v:3'));
+    });
+
+    test('AsyncStorage (async fetch error)', () async {
+      var storage = AsyncStorage();
+
+      expect(storage.canFetch, isFalse);
+
+      var fetchCount = 0;
+
+      var field = storage.getField<String>('a').withFetcher((f) {
+        return Future.microtask(() {
+          var c = ++fetchCount;
+          if (c == 1) {
+            throw StateError("Fetch Error");
+          }
+          return 'v:$c';
+        });
+      });
+
+      expect(field.canRefresh, isTrue);
+
+      expect(field.isSet, isFalse);
+      expect(field.value, isNull);
+
+      await expectLater(
+          () async => field.get(),
+          throwsA(isA<StateError>()
+              .having((e) => e.message, 'message', equals('Fetch Error'))));
+
+      expect(field.isSet, isFalse);
+      expect(field.value, isNull);
+
+      expect(await field.get(), equals('v:2'));
+
+      expect(field.isSet, isTrue);
+      expect(field.value, isNotNull);
+      expect(field.value, equals('v:2'));
+
+      expect(await field.get(), equals('v:2'));
+
+      expect(field.isSet, isTrue);
+      expect(field.value, isNotNull);
+      expect(field.value, equals('v:2'));
+
+      expect(await field.refresh(), equals('v:3'));
+
+      expect(field.isSet, isTrue);
+      expect(field.value, isNotNull);
+      expect(field.value, equals('v:3'));
+    });
+
     test('Closed AsyncStorage', () async {
       var storage = AsyncStorage();
 


### PR DESCRIPTION
- `AsyncField`:
  - `refresh`: ensure that `_fetching` is removed on error.

- collection: ^1.18.0
- async_extension: ^1.2.12
- lints: ^3.0.0
- test: ^1.25.5
- dependency_validator: ^3.2.3
- coverage: ^1.8.0